### PR TITLE
Support Jackson subtypes as discriminated unions

### DIFF
--- a/apina-core/src/main/kotlin/fi/evident/apina/java/model/JavaAnnotation.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/java/model/JavaAnnotation.kt
@@ -26,6 +26,9 @@ class JavaAnnotation(val name: JavaType.Basic) {
     inline fun <reified T : Any> getAttribute(name: String): T? =
         getAttribute(name, T::class.java)
 
+    inline fun <reified T : Any> getRequiredAttribute(name: String): T =
+        getAttribute(name, T::class.java) ?: error("Required attribute $name missing for $name")
+
     fun <T : Any> getAttribute(name: String, type: Class<T>): T? {
         val value = attributes[name] ?: return null
 

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/ApiDefinition.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/ApiDefinition.kt
@@ -12,6 +12,7 @@ class ApiDefinition {
     private val _endpointGroups = ArrayList<EndpointGroup>()
     private val _classDefinitions = TreeMap<ApiTypeName, ClassDefinition>()
     private val _enumDefinitions = TreeMap<ApiTypeName, EnumDefinition>()
+    private val _discriminatedUnionDefinitions = TreeMap<ApiTypeName, DiscriminatedUnionDefinition>()
     private val blackBoxTypes = LinkedHashSet<ApiTypeName>()
 
     val endpointGroups: Collection<EndpointGroup>
@@ -23,12 +24,15 @@ class ApiDefinition {
     val enumDefinitions: Collection<EnumDefinition>
         get() = _enumDefinitions.values
 
+    val discriminatedUnionDefinitions: Collection<DiscriminatedUnionDefinition>
+        get() = _discriminatedUnionDefinitions.values
+
     fun addEndpointGroups(group: EndpointGroup) {
         _endpointGroups += group
     }
 
     fun containsType(typeName: ApiTypeName) =
-        typeName in _classDefinitions || typeName in _enumDefinitions
+        typeName in _classDefinitions || typeName in _enumDefinitions || typeName in _discriminatedUnionDefinitions
 
     fun addClassDefinition(classDefinition: ClassDefinition) {
         verifyTypeDoesNotExist(classDefinition.type)
@@ -40,6 +44,12 @@ class ApiDefinition {
         verifyTypeDoesNotExist(enumDefinition.type)
 
         _enumDefinitions[enumDefinition.type] = enumDefinition
+    }
+
+    fun addDiscriminatedUnion(definition: DiscriminatedUnionDefinition) {
+        verifyTypeDoesNotExist(definition.type)
+
+        _discriminatedUnionDefinitions[definition.type] = definition
     }
 
     fun addBlackBox(type: ApiTypeName) {

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/DiscriminatedUnionDefinition.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/DiscriminatedUnionDefinition.kt
@@ -1,0 +1,22 @@
+package fi.evident.apina.model
+
+import fi.evident.apina.model.type.ApiType
+import fi.evident.apina.model.type.ApiTypeName
+import java.util.*
+
+class DiscriminatedUnionDefinition(
+    val type: ApiTypeName,
+    val discriminator: String) {
+
+    private val _types = TreeMap<String, ApiType>()
+
+    val types: SortedMap<String, ApiType>
+        get() = _types
+
+    fun addType(discriminator: String, type: ApiType) {
+        val old = types.putIfAbsent(discriminator, type)
+        check(old == null) { "Tried to add duplicated case '$discriminator' to discriminated union '$type" }
+    }
+
+    override fun toString() = type.toString()
+}

--- a/manual/src/asciidoc/_03-jackson.adoc
+++ b/manual/src/asciidoc/_03-jackson.adoc
@@ -77,8 +77,8 @@ the sub-types and define their discriminator values explicitly:
 ----
 @JsonTypeInfo(use=NAME, property="type")
 @JsonSubTypes(
-    Type(value = Bar::class, name = "my_foo"),
-    Type(value = Baz::class, name = "my_bar")
+    Type(value = Bar::class, name = "my_bar"),
+    Type(value = Baz::class, name = "my_baz")
 )
 abstract class Foo { ... }
 
@@ -92,11 +92,11 @@ This creates interfaces normally for `Bar` and `Baz` and then adds the following
 [source,typescript]
 ----
 export interface Foo_Bar extends Bar {
-    type = "my_foo";
+    type: "my_bar";
 }
 
 export interface Foo_Baz extends Baz {
-    type = "my_bar";
+    type: "my_baz";
 }
 
 export type Foo = Foo_Bar | Foo_Baz;
@@ -106,7 +106,7 @@ This way you can easily pass heterogeneous data back and forth between client an
 
 === Supported annotations
 
-That said, straightforward Jackson mappings should generally work without hassle. Most of the type you don't
+That said, straightforward Jackson mappings should generally work without hassle. Most of the time you don't
 need any annotations. When you need to control the mappings, following Jackson annotations are recognized
 by Apina as well:
 


### PR DESCRIPTION
Support converting subclasses to TypeScript discriminated unions when Jackson subclass mapping has been explicitly specified with `@JsonTypeInfo(use=NAME, include=PROPERTY, property="...")` and `@JsonSubTypes`.

Example:

```java
@JsonTypeInfo(use=NAME, property="type")
@JsonSubTypes({ 
    @Type(value = Bar.class, name = "my_bar"), 
    @Type(value = Baz.class, name = "my_baz") 
})
abstract class Foo { ... }
```

This translates `Bar` and `Baz` normally, but in addition to these, creates some extra types for this union:

```typescript
export interface Foo_Bar extends Bar {
    type: "my_bar";
}

export interface Foo_Baz extends Baz {
    type: "my_baz";
}

export type Foo = Foo_Bar | Foo_Baz;
```

Corresponding serializers are also automatically registered.

Closes #42 
