### PR TITLE
Fix race condition regarding the creation of shadowJar

### DIFF
--- a/apina-cli/build.gradle.kts
+++ b/apina-cli/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
     kotlin("jvm")
-    id("com.github.johnrengelman.shadow") version "4.0.2"
+    id("com.github.johnrengelman.shadow") version "5.2.0"
 }
 
 dependencies {
@@ -15,4 +15,8 @@ application {
 
 tasks.assemble {
     dependsOn(tasks.shadowJar)
+}
+
+tasks.shadowJar {
+    classifier = "all"
 }


### PR DESCRIPTION
Hi

This commit fixes some ordering violations in build script. Specifically, the task `shadowJar` of the subproject `apina-cli` generates a shadow jar (`apina-cli-0.12.4.jar`), which conflicts with that generated by the naive jar task.

As a result, the contents of the jar file might be different depending on the order in which gradle runs task. For example this is the correct contents of the jar `apina-cli-0.12.4.jar` (when the task shadowJar is executed after jar).

```
META-INF/
META-INF/MANIFEST.MF
META-INF/apina-cli.kotlin_module
fi/
fi/evident/
fi/evident/apina/
fi/evident/apina/cli/
fi/evident/apina/cli/Apina.class
fi/evident/apina/cli/CommandLineArguments$ImportArgument.class
fi/evident/apina/cli/CommandLineArguments.class
fi/evident/apina/cli/CommandLineArguments$Companion.class
logback.xml
META-INF/apina-core.kotlin_module
fi/evident/apina/spring/
fi/evident/apina/spring/SpringAnnotation$getAttribute$1.class
fi/evident/apina/spring/SpringAnnotation$findAliasTargets$1.class
fi/evident/apina/spring/JacksonTypeTranslator$initClassDefinition$acceptProperty$1.class
fi/evident/apina/spring/SpringAnnotation$findAliases$1.class
fi/evident/apina/spring/DuplicateClassNameException.class
fi/evident/apina/spring/SpringAnnotationResolver$findImpliedAnnotations$1.class
fi/evident/apina/spring/JacksonTypeTranslator$Companion.class
fi/evident/apina/spring/SpringModelReader$Companion.class
fi/evident/apina/spring/AliasFor.class
fi/evident/apina/spring/SpringTypes.class
fi/evident/apina/spring/NullabilityAnnotationsKt.class
fi/evident/apina/spring/SpringUriTemplateParserKt.class
fi/evident/apina/spring/EndpointParameterNameNotDefinedException.class
fi/evident/apina/spring/SpringUriTemplateParser.class
fi/evident/apina/spring/SpringModelReader$parseParameter$1.class
fi/evident/apina/spring/SpringAnnotation$getAttributeFrom$1.class
fi/evident/apina/spring/SpringModelReader$createEndpointsForControllers$1.class
fi/evident/apina/spring/SpringAnnotation$findAliases$2.class
fi/evident/apina/spring/SpringAnnotationResolver.class
fi/evident/apina/spring/SpringAnnotation$getAttributeFrom$2.class
fi/evident/apina/spring/SpringModelReader.class
fi/evident/apina/spring/SpringAnnotation.class
fi/evident/apina/spring/NameTranslatorKt.class
fi/evident/apina/spring/JacksonTypeTranslator.class
fi/evident/apina/model/
fi/evident/apina/model/Endpoint.class
fi/evident/apina/model/PropertyDefinition.class
fi/evident/apina/model/ApiDefinition$endpointGroups$$inlined$sortedBy$1.class
fi/evident/apina/model/ApiDefinition$unknownTypeReferences$resultTypes$2.class
fi/evident/apina/model/ApiDefinition$unknownTypeReferences$propertyTypes$1.class
fi/evident/apina/model/EnumDefinition.class
fi/evident/apina/model/EndpointGroup.class
fi/evident/apina/model/ApiDefinition$unknownTypeReferences$2.class
fi/evident/apina/model/Endpoint$requestBody$$inlined$filterIsInstance$1.class
fi/evident/apina/model/parameters/
... and many more
```

And these are the contents of jar when `shadowJar` is executed before `jar`.

```
META-INF/
META-INF/MANIFEST.MF
META-INF/apina-cli.kotlin_module
fi/
fi/evident/
fi/evident/apina/
fi/evident/apina/cli/
fi/evident/apina/cli/Apina.class
fi/evident/apina/cli/CommandLineArguments$ImportArgument.class
fi/evident/apina/cli/CommandLineArguments.class
fi/evident/apina/cli/CommandLineArguments$Companion.class
logback.xml
```

This commit fixes this issue by adding a classifier (`-all`) for the generated shadowJar