### PR TITLE
Add switch for generating types with undefined instead of null

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ apina {
     
     // How nullables are translated to TypeScript interfaces? (Default mode is 'NULL'.)
     //  - 'NULL'      => name: Type | null
-    //  - 'UNDEFINED' => name: Type | undefined
+    //  - 'UNDEFINED' => name?: Type
     optionalTypeMode = OptionalTypeMode.NULL
     
     // Which controllers to include when generating API? Defaults to everything.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ apina {
     //  - 'default'      => enum MyEnum { FOO = "FOO", BAR = "BAR", BAZ = "BAZ" }
     //  - 'int_enum'     => enum MyEnum { FOO, BAR, BAZ }
     //  - 'string_union' => type MyEnum = "FOO" | "BAR" | "BAZ"
-    enumMode = 'default' 
+    enumMode = 'default'
+    
+    // How nullables are translated to TypeScript interfaces? (Default mode is 'NULL'.)
+    //  - 'NULL'      => name: Type | null
+    //  - 'UNDEFINED' => name: Type | undefined
+    optionalTypeMode = OptionalTypeMode.NULL
     
     // Which controllers to include when generating API? Defaults to everything.
     endpoints = [/my\.package\.foo\..+/]

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/Endpoint.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/Endpoint.kt
@@ -20,8 +20,7 @@ class Endpoint(
     /** URI template for the endpoint  */
     val uriTemplate: URITemplate,
     val responseBody: ApiType?,
-    val generateUrlMethod: Boolean,
-    val optionalTypeMode: OptionalTypeMode
+    val generateUrlMethod: Boolean
 ) {
 
     private val _parameters = ArrayList<EndpointParameter>()
@@ -49,7 +48,7 @@ class Endpoint(
         get() = _parameters.filterIsInstance<EndpointRequestParamParameter>()
 
     override fun toString(): String = String.format("%s %s(%s): %s %s",
-            responseBody?.toTypeScript(optionalTypeMode) ?: "void",
+            responseBody?.toTypeScript(OptionalTypeMode.NULL) ?: "void",
             name,
             _parameters.joinToString(", "),
             method,

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/Endpoint.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/Endpoint.kt
@@ -4,6 +4,7 @@ import fi.evident.apina.model.parameters.EndpointParameter
 import fi.evident.apina.model.parameters.EndpointPathVariableParameter
 import fi.evident.apina.model.parameters.EndpointRequestBodyParameter
 import fi.evident.apina.model.parameters.EndpointRequestParamParameter
+import fi.evident.apina.model.settings.OptionalTypeMode
 import fi.evident.apina.model.type.ApiType
 import java.util.*
 
@@ -19,7 +20,8 @@ class Endpoint(
     /** URI template for the endpoint  */
     val uriTemplate: URITemplate,
     val responseBody: ApiType?,
-    val generateUrlMethod: Boolean
+    val generateUrlMethod: Boolean,
+    val optionalTypeMode: OptionalTypeMode
 ) {
 
     private val _parameters = ArrayList<EndpointParameter>()
@@ -47,7 +49,7 @@ class Endpoint(
         get() = _parameters.filterIsInstance<EndpointRequestParamParameter>()
 
     override fun toString(): String = String.format("%s %s(%s): %s %s",
-            responseBody?.toTypeScript() ?: "void",
+            responseBody?.toTypeScript(optionalTypeMode) ?: "void",
             name,
             _parameters.joinToString(", "),
             method,

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/settings/OptionalTypeMode.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/settings/OptionalTypeMode.kt
@@ -1,0 +1,6 @@
+package fi.evident.apina.model.settings
+
+enum class OptionalTypeMode {
+    NULL,
+    UNDEFINED
+}

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/settings/TranslationSettings.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/settings/TranslationSettings.kt
@@ -18,6 +18,7 @@ class TranslationSettings {
     val nameTranslator = NameTranslator()
     var platform = Platform.ANGULAR
     var typeWriteMode = TypeWriteMode.INTERFACE
+    var optionalTypeMode = OptionalTypeMode.NULL
     var enumMode = EnumMode.DEFAULT
     var removedUrlPrefix = ""
 

--- a/apina-core/src/main/kotlin/fi/evident/apina/model/type/ApiType.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/model/type/ApiType.kt
@@ -4,7 +4,7 @@ import fi.evident.apina.model.settings.OptionalTypeMode
 
 sealed class ApiType {
 
-    abstract fun toTypeScript(optionalTypeMode: OptionalTypeMode = OptionalTypeMode.NULL): String
+    abstract fun toTypeScript(optionalTypeMode: OptionalTypeMode): String
     abstract fun toSwift(): String
     open fun unwrapNullable(): ApiType = this
 

--- a/apina-core/src/main/kotlin/fi/evident/apina/output/ts/AbstractTypeScriptGenerator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/output/ts/AbstractTypeScriptGenerator.kt
@@ -5,6 +5,7 @@ import fi.evident.apina.model.parameters.EndpointParameter
 import fi.evident.apina.model.parameters.EndpointPathVariableParameter
 import fi.evident.apina.model.parameters.EndpointRequestParamParameter
 import fi.evident.apina.model.settings.EnumMode
+import fi.evident.apina.model.settings.OptionalTypeMode
 import fi.evident.apina.model.settings.TranslationSettings
 import fi.evident.apina.model.settings.TypeWriteMode
 import fi.evident.apina.model.type.ApiType
@@ -64,7 +65,7 @@ abstract class AbstractTypeScriptGenerator(
             out.writeLine("export type ${type.name} = {};")
 
         for ((alias, target) in api.typeAliases)
-            out.writeLine("export type ${alias.name} = ${target.toTypeScript()};")
+            out.writeLine("export type ${alias.name} = ${target.toTypeScript(settings.optionalTypeMode)};")
 
         out.writeLine()
 
@@ -81,7 +82,7 @@ abstract class AbstractTypeScriptGenerator(
         for (classDefinition in api.structuralTypeDefinitions) {
             classDefinitionWriter(classDefinition.type.name) {
                 for (property in classDefinition.properties)
-                    out.writeLine("${property.name}: ${property.type.toTypeScript()};")
+                    out.writeLine("${property.name}: ${property.type.toTypeScript(settings.optionalTypeMode)};")
             }
         }
 
@@ -146,7 +147,7 @@ abstract class AbstractTypeScriptGenerator(
                 val defs = LinkedHashMap<String, String>()
 
                 for (property in classDefinition.properties)
-                    defs[property.name] = typeDescriptor(property.type)
+                    defs[property.name] = typeDescriptor(property.type, settings.optionalTypeMode)
 
                 out.write("config.registerClassSerializer(").writeValue(classDefinition.type.toString()).write(", ")
                 out.writeValue(defs).writeLine(");")
@@ -157,7 +158,7 @@ abstract class AbstractTypeScriptGenerator(
                 val defs = mutableMapOf<String, String>()
 
                 for ((discriminatorValue, type) in definition.types)
-                    defs[discriminatorValue] = typeDescriptor(ApiType.Class(type.type))
+                    defs[discriminatorValue] = typeDescriptor(ApiType.Class(type.type), settings.optionalTypeMode)
 
                 out.write("config.registerDiscriminatedUnionSerializer(")
                 out.writeValue(definition.type.name).write(", ")
@@ -208,7 +209,7 @@ abstract class AbstractTypeScriptGenerator(
         val signature = "${endpoint.name}($parameters): $resultFunctor<$resultType>"
 
         out.write(signature).write(" ").writeBlock {
-            out.write("return this.context.request(").writeValue(createConfig(endpoint)).writeLine(");")
+            out.write("return this.context.request(").writeValue(createConfig(endpoint, optionalTypeMode = settings.optionalTypeMode)).writeLine(");")
         }
     }
 
@@ -217,16 +218,19 @@ abstract class AbstractTypeScriptGenerator(
         val signature = "${endpoint.name}Url($parameters): string"
 
         out.write(signature).write(" ").writeBlock {
-            out.write("return this.context.url(").writeValue(createConfig(endpoint, onlyUrl = true)).writeLine(");")
+            out.write("return this.context.url(").writeValue(createConfig(endpoint, onlyUrl = true, optionalTypeMode = settings.optionalTypeMode)).writeLine(");")
         }
     }
 
     private fun qualifiedTypeName(type: ApiType): String = when {
-        type is ApiType.Nullable -> qualifiedTypeName(type.type) + " | null"
-        type is ApiType.Primitive -> type.toTypeScript()
+        type is ApiType.Nullable -> when (settings.optionalTypeMode) {
+            OptionalTypeMode.UNDEFINED -> qualifiedTypeName(type.type) + " | undefined"
+            OptionalTypeMode.NULL -> qualifiedTypeName(type.type) + " | null"
+        }
+        type is ApiType.Primitive -> type.toTypeScript(settings.optionalTypeMode)
         type is ApiType.Array -> qualifiedTypeName(type.elementType) + "[]"
-        settings.isImported(ApiTypeName(type.toTypeScript())) -> type.toTypeScript()
-        else -> type.toTypeScript()
+        settings.isImported(ApiTypeName(type.toTypeScript(settings.optionalTypeMode))) -> type.toTypeScript(settings.optionalTypeMode)
+        else -> type.toTypeScript(settings.optionalTypeMode)
     }
 
     private fun discriminatedUnionMemberType(unionType: ApiTypeName, memberType: ClassDefinition) =
@@ -250,7 +254,7 @@ abstract class AbstractTypeScriptGenerator(
                 .distinctBy { it.type }
                 .sortedBy { it.type }
 
-        private fun createConfig(endpoint: Endpoint, onlyUrl: Boolean = false): Map<String, Any> {
+        private fun createConfig(endpoint: Endpoint, onlyUrl: Boolean = false, optionalTypeMode: OptionalTypeMode): Map<String, Any> {
             val config = LinkedHashMap<String, Any>()
 
             config["uriTemplate"] = endpoint.uriTemplate.toString()
@@ -260,34 +264,43 @@ abstract class AbstractTypeScriptGenerator(
 
             val pathVariables = endpoint.pathVariables
             if (pathVariables.isNotEmpty())
-                config["pathVariables"] = createPathVariablesMap(pathVariables)
+                config["pathVariables"] = createPathVariablesMap(pathVariables, optionalTypeMode)
 
             val requestParameters = endpoint.requestParameters
             if (requestParameters.isNotEmpty())
-                config["requestParams"] = createRequestParamMap(requestParameters)
+                config["requestParams"] = createRequestParamMap(requestParameters, optionalTypeMode)
 
             if (!onlyUrl) {
-                endpoint.requestBody?.let { body -> config["requestBody"] = serialize(body.name, body.type.unwrapNullable()) }
-                endpoint.responseBody?.let { body -> config["responseType"] = typeDescriptor(body) }
+                endpoint.requestBody?.let { body -> config["requestBody"] = serialize(body.name, body.type.unwrapNullable(), optionalTypeMode) }
+                endpoint.responseBody?.let { body -> config["responseType"] = typeDescriptor(
+                    body,
+                    optionalTypeMode
+                ) }
             }
 
             return config
         }
 
-        private fun createRequestParamMap(parameters: Collection<EndpointRequestParamParameter>): Map<String, Any> {
+        private fun createRequestParamMap(
+            parameters: Collection<EndpointRequestParamParameter>,
+            optionalTypeMode: OptionalTypeMode
+        ): Map<String, Any> {
             val result = LinkedHashMap<String, Any>()
 
             for (param in parameters)
-                result[param.queryParameter] = serialize(param.name, param.type)
+                result[param.queryParameter] = serialize(param.name, param.type, optionalTypeMode)
 
             return result
         }
 
-        private fun createPathVariablesMap(pathVariables: List<EndpointPathVariableParameter>): Map<String, Any> {
+        private fun createPathVariablesMap(
+            pathVariables: List<EndpointPathVariableParameter>,
+            optionalTypeMode: OptionalTypeMode
+        ): Map<String, Any> {
             val result = LinkedHashMap<String, Any>()
 
             for (param in pathVariables)
-                result[param.pathVariable] = serialize(param.name, param.type)
+                result[param.pathVariable] = serialize(param.name, param.type, optionalTypeMode)
 
             return result
         }
@@ -296,13 +309,13 @@ abstract class AbstractTypeScriptGenerator(
          * Returns TypeScript code to serialize `variable` of given `type`
          * to transfer representation.
          */
-        private fun serialize(variable: String, type: ApiType) =
-            RawCode("this.context.serialize(" + variable + ", '" + typeDescriptor(type) + "')")
+        private fun serialize(variable: String, type: ApiType, optionalTypeMode: OptionalTypeMode) =
+            RawCode("this.context.serialize(" + variable + ", '" + typeDescriptor(type, optionalTypeMode) + "')")
 
-        private fun typeDescriptor(type: ApiType): String {
+        private fun typeDescriptor(type: ApiType, optionalTypeMode: OptionalTypeMode): String {
             // Use ApiType's native representation as type descriptor.
             // This method encapsulates the call to make it meaningful in this context.
-            return type.unwrapNullable().toTypeScript()
+            return type.unwrapNullable().toTypeScript(optionalTypeMode)
         }
     }
 }

--- a/apina-core/src/main/kotlin/fi/evident/apina/spring/SpringModelReader.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/spring/SpringModelReader.kt
@@ -55,8 +55,7 @@ class SpringModelReader private constructor(private val classes: JavaModel, priv
             name = method.name,
             uriTemplate = resolveUriTemplate(method, owningClass),
             responseBody = resolveResponseBody(method, boundClass.environment),
-            generateUrlMethod = settings.isUrlEndpoint(owningClass.name, method.name),
-            optionalTypeMode = settings.optionalTypeMode
+            generateUrlMethod = settings.isUrlEndpoint(owningClass.name, method.name)
         )
 
         resolveRequestMethod(method)?.let { endpoint.method = it }

--- a/apina-core/src/main/kotlin/fi/evident/apina/spring/SpringModelReader.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/spring/SpringModelReader.kt
@@ -55,7 +55,8 @@ class SpringModelReader private constructor(private val classes: JavaModel, priv
             name = method.name,
             uriTemplate = resolveUriTemplate(method, owningClass),
             responseBody = resolveResponseBody(method, boundClass.environment),
-            generateUrlMethod = settings.isUrlEndpoint(owningClass.name, method.name)
+            generateUrlMethod = settings.isUrlEndpoint(owningClass.name, method.name),
+            optionalTypeMode = settings.optionalTypeMode
         )
 
         resolveRequestMethod(method)?.let { endpoint.method = it }

--- a/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
@@ -8,14 +8,14 @@ class ApiTypeTest {
 
     @Test
     fun `TypeScript representations`() {
-        assertEquals("string", ApiType.Primitive.STRING.toTypeScript())
-        assertEquals("string[]", ApiType.Array(ApiType.Primitive.STRING).toTypeScript())
-        assertEquals("string[][]", ApiType.Array(ApiType.Array(ApiType.Primitive.STRING)).toTypeScript())
-        assertEquals("Foo", ApiType.BlackBox(ApiTypeName("Foo")).toTypeScript())
-        assertEquals("Foo", ApiType.Class(ApiTypeName("Foo")).toTypeScript())
-        assertEquals("Dictionary<string>", ApiType.Dictionary(ApiType.Primitive.STRING).toTypeScript())
-        assertEquals("Dictionary<string | null>", ApiType.Dictionary(ApiType.Nullable(ApiType.Primitive.STRING)).toTypeScript())
-        assertEquals("string | null", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript())
+        assertEquals("string", ApiType.Primitive.STRING.toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("string[]", ApiType.Array(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("string[][]", ApiType.Array(ApiType.Array(ApiType.Primitive.STRING)).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("Foo", ApiType.BlackBox(ApiTypeName("Foo")).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("Foo", ApiType.Class(ApiTypeName("Foo")).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("Dictionary<string>", ApiType.Dictionary(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("Dictionary<string | null>", ApiType.Dictionary(ApiType.Nullable(ApiType.Primitive.STRING)).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("string | null", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.NULL))
         assertEquals("string | undefined", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.UNDEFINED))
     }
 

--- a/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
@@ -15,6 +15,7 @@ class ApiTypeTest {
         assertEquals("Foo", ApiType.Class(ApiTypeName("Foo")).toTypeScript(OptionalTypeMode.NULL))
         assertEquals("Dictionary<string>", ApiType.Dictionary(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.NULL))
         assertEquals("Dictionary<string | null>", ApiType.Dictionary(ApiType.Nullable(ApiType.Primitive.STRING)).toTypeScript(OptionalTypeMode.NULL))
+        assertEquals("Dictionary<string | undefined>", ApiType.Dictionary(ApiType.Nullable(ApiType.Primitive.STRING)).toTypeScript(OptionalTypeMode.UNDEFINED))
         assertEquals("string | null", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.NULL))
         assertEquals("string | undefined", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.UNDEFINED))
     }

--- a/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/model/type/ApiTypeTest.kt
@@ -1,5 +1,6 @@
 package fi.evident.apina.model.type
 
+import fi.evident.apina.model.settings.OptionalTypeMode
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -13,7 +14,9 @@ class ApiTypeTest {
         assertEquals("Foo", ApiType.BlackBox(ApiTypeName("Foo")).toTypeScript())
         assertEquals("Foo", ApiType.Class(ApiTypeName("Foo")).toTypeScript())
         assertEquals("Dictionary<string>", ApiType.Dictionary(ApiType.Primitive.STRING).toTypeScript())
+        assertEquals("Dictionary<string | null>", ApiType.Dictionary(ApiType.Nullable(ApiType.Primitive.STRING)).toTypeScript())
         assertEquals("string | null", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript())
+        assertEquals("string | undefined", ApiType.Nullable(ApiType.Primitive.STRING).toTypeScript(OptionalTypeMode.UNDEFINED))
     }
 
     @Test

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/JacksonTypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/JacksonTypeTranslatorTest.kt
@@ -15,6 +15,7 @@ import fi.evident.apina.model.ClassDefinition
 import fi.evident.apina.model.EnumDefinition
 import fi.evident.apina.model.ModelMatchers.hasProperties
 import fi.evident.apina.model.ModelMatchers.property
+import fi.evident.apina.model.settings.OptionalTypeMode
 import fi.evident.apina.model.settings.TranslationSettings
 import fi.evident.apina.model.type.ApiType
 import fi.evident.apina.model.type.ApiTypeName
@@ -406,7 +407,7 @@ class JacksonTypeTranslatorTest {
         val api = ApiDefinition()
         val apiType = translateClass<T>(api)
 
-        return api.classDefinitions.find { d -> apiType.toTypeScript().startsWith(d.type.toString()) }
+        return api.classDefinitions.find { d -> apiType.toTypeScript(OptionalTypeMode.NULL).startsWith(d.type.toString()) }
             ?: throw AssertionError("could not find definition for $apiType")
     }
 
@@ -414,7 +415,7 @@ class JacksonTypeTranslatorTest {
         val api = ApiDefinition()
         val apiType = translateClass<T>(api)
 
-        return api.enumDefinitions.find { d -> d.type.toString() == apiType.toTypeScript() }
+        return api.enumDefinitions.find { d -> d.type.toString() == apiType.toTypeScript(OptionalTypeMode.NULL) }
             ?: throw AssertionError("could not find definition for $apiType")
     }
 

--- a/apina-gradle/src/main/kotlin/fi/evident/apina/gradle/tasks/ApinaTask.kt
+++ b/apina-gradle/src/main/kotlin/fi/evident/apina/gradle/tasks/ApinaTask.kt
@@ -5,6 +5,7 @@ package fi.evident.apina.gradle.tasks
 import fi.evident.apina.ApinaProcessor
 import fi.evident.apina.java.reader.Classpath
 import fi.evident.apina.model.settings.EnumMode
+import fi.evident.apina.model.settings.OptionalTypeMode
 import fi.evident.apina.model.settings.Platform
 import fi.evident.apina.model.settings.TypeWriteMode
 import fi.evident.apina.spring.EndpointParameterNameNotDefinedException
@@ -50,6 +51,9 @@ open class ApinaTask : DefaultTask() {
     var typeWriteMode = TypeWriteMode.INTERFACE
 
     @get:Input
+    var optionalTypeMode = OptionalTypeMode.NULL
+
+    @get:Input
     var enumMode = EnumMode.DEFAULT
 
     @get:Input
@@ -82,6 +86,7 @@ open class ApinaTask : DefaultTask() {
             processor.settings.removedUrlPrefix = removedUrlPrefix
             processor.settings.platform = platform
             processor.settings.typeWriteMode = typeWriteMode
+            processor.settings.optionalTypeMode = optionalTypeMode
 
             endpoints.forEach { processor.settings.addControllerPattern(it) }
             endpointUrlMethods.forEach { processor.settings.addEndpointUrlMethodPattern(it) }

--- a/manual/src/asciidoc/_06-gradle.adoc
+++ b/manual/src/asciidoc/_06-gradle.adoc
@@ -25,6 +25,11 @@ tasks.apina {
     //  - 'STRING_UNION' => type MyEnum = "FOO" | "BAR" | "BAZ"
     enumMode = EnumMode.DEFAULT
 
+    // How nullables are translated to TypeScript interfaces? (Default mode is 'NULL'.)
+    //  - 'NULL'      => name: Type | null
+    //  - 'UNDEFINED' => name?: Type
+    optionalTypeMode = OptionalTypeMode.NULL
+
     // Which controllers to include when generating API? Defaults to everything.
     // Given regexes may safely match other things that are not controllers, but it pays to
     // limit the scope because otherwise Apina needs to parse bytecode of all the classes

--- a/manual/src/asciidoc/_06-gradle.adoc
+++ b/manual/src/asciidoc/_06-gradle.adoc
@@ -27,7 +27,7 @@ tasks.apina {
 
     // How nullables are translated to TypeScript interfaces? (Default mode is 'NULL'.)
     //  - 'NULL'      => name: Type | null
-    //  - 'UNDEFINED' => name: Type | undefined
+    //  - 'UNDEFINED' => name?: Type
     optionalTypeMode = OptionalTypeMode.NULL
 
     // Which controllers to include when generating API? Defaults to everything.

--- a/manual/src/asciidoc/_06-gradle.adoc
+++ b/manual/src/asciidoc/_06-gradle.adoc
@@ -27,7 +27,7 @@ tasks.apina {
 
     // How nullables are translated to TypeScript interfaces? (Default mode is 'NULL'.)
     //  - 'NULL'      => name: Type | null
-    //  - 'UNDEFINED' => name?: Type
+    //  - 'UNDEFINED' => name: Type | undefined
     optionalTypeMode = OptionalTypeMode.NULL
 
     // Which controllers to include when generating API? Defaults to everything.


### PR DESCRIPTION
What do you think about providing option to select if we want to generate Nullables as null or undefined in typescript? This would be useful if jackson is configured to drop null values from the serialized json. Also it would make it a bit easier for using optional chaining (which converts null/undefined to undefined, but then undefined could not be passed on to parameters for api calls (because it needs null, not undefined). And also for example `someType?.prop` wouldn't return undefined but instead null if it's missing (but `someType?.anotherMissingProp` would return undefined). Also it could be better to use `prop?: string` syntax, but I think it would require more complex changes to apina implementation than this would.

```
export interface SomeType {
    prop: string | null;
}

export class ExampleEndpoint {

    method(prop: string | null): ...
```

when using optional this would be:

```
export interface SomeType {
    prop: string | undefined;
}

export class ExampleEndpoint {

    method(prop: string | undefined): ...
```

I'm not sure if I've covered all the bits and pieces here, but let me know what do you think :)

