### PR TITLE
Support value classes

### DIFF
--- a/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
@@ -1,15 +1,12 @@
 package fi.evident.apina.utils
 
 fun propertyNameForGetter(getterName: String): String =
-    when {
-        // Value/inline classes result in name suffixed with hash
-        getterName.contains("-") -> propertyNameForSimpleGetter(getterName.substringBefore('-'))
-        else -> propertyNameForSimpleGetter(getterName)
-    }
+    // Value/inline classes result in name suffixed with hash
+    propertyNameForSimpleGetter(getterName.substringBefore('-'))
 
 private fun propertyNameForSimpleGetter(getterName: String): String =
     when {
-        getterName.startsWith("get") -> getterName.removePrefix("get").decapitalize()
-        getterName.startsWith("is") -> getterName.removePrefix("is").decapitalize()
+        getterName.startsWith("get") -> getterName.removePrefix("get").replaceFirstChar { it.lowercase() }
+        getterName.startsWith("is") -> getterName.removePrefix("is").replaceFirstChar { it.lowercase() }
         else -> error("not a valid name for getter $getterName")
     }

--- a/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
@@ -1,7 +1,5 @@
 package fi.evident.apina.utils
 
-import java.util.Locale
-
 fun propertyNameForGetter(getterName: String): String =
     when {
         // Value/inline classes result in name suffixed with hash
@@ -11,9 +9,7 @@ fun propertyNameForGetter(getterName: String): String =
 
 private fun propertyNameForSimpleGetter(getterName: String): String =
     when {
-        getterName.startsWith("get") -> getterName.removePrefix("get")
-            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
-        getterName.startsWith("is") -> getterName.removePrefix("is")
-            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+        getterName.startsWith("get") -> getterName.removePrefix("get").decapitalize()
+        getterName.startsWith("is") -> getterName.removePrefix("is").decapitalize()
         else -> error("not a valid name for getter $getterName")
     }

--- a/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/utils/PropertyUtils.kt
@@ -1,8 +1,19 @@
 package fi.evident.apina.utils
 
+import java.util.Locale
+
 fun propertyNameForGetter(getterName: String): String =
     when {
-        getterName.startsWith("get") -> getterName.removePrefix("get").decapitalize()
-        getterName.startsWith("is") -> getterName.removePrefix("is").decapitalize()
+        // Value/inline classes result in name suffixed with hash
+        getterName.contains("-") -> propertyNameForSimpleGetter(getterName.substringBefore('-'))
+        else -> propertyNameForSimpleGetter(getterName)
+    }
+
+private fun propertyNameForSimpleGetter(getterName: String): String =
+    when {
+        getterName.startsWith("get") -> getterName.removePrefix("get")
+            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+        getterName.startsWith("is") -> getterName.removePrefix("is")
+            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
         else -> error("not a valid name for getter $getterName")
     }

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
@@ -45,7 +45,8 @@ class TypeTranslatorTest {
         assertThat(classDefinition.properties, hasProperties(
             property("valueString", ApiType.Primitive.STRING),
             property("valueInteger", ApiType.Primitive.INTEGER),
-            property("privateValue", ApiType.Primitive.STRING)))
+            property("nestedValueInteger", ApiType.Primitive.INTEGER),
+            property("getterValue", ApiType.Primitive.STRING)))
     }
 
     @Test

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
@@ -31,12 +31,22 @@ import java.util.Collections.singletonMap
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import kotlinx.serialization.Serializable
 import kotlin.test.fail
 
 class TypeTranslatorTest {
 
     private val settings = TranslationSettings()
+
+    @Test
+    fun translatingClassWithValueAndInlineClasses() {
+        val classDefinition = translateClass<ClassWithValueClasses>()
+
+        assertEquals(ApiTypeName(ClassWithValueClasses::class.java.simpleName), classDefinition.type)
+        assertThat(classDefinition.properties, hasProperties(
+            property("valueString", ApiType.Primitive.STRING),
+            property("valueInteger", ApiType.Primitive.INTEGER),
+            property("privateValue", ApiType.Primitive.STRING)))
+    }
 
     @Test
     fun translatingClassWithFieldProperties() {

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
@@ -406,7 +406,8 @@ class TypeTranslatorTest {
                 @kotlinx.serialization.SerialName("overriddenName") val propertyWithOverriddenName: String,
                 val fieldWithDefaultWillBeNullable: Int = 42,
                 @kotlinx.serialization.Required val requiredFieldWithDefaultWillNotBeNullable: Int = 42,
-                val nullableParameter: Int?
+                val nullableParameter: Int?,
+                val valueString: ValueString
             )
 
             val classDefinition = translateClass<Example>()
@@ -416,7 +417,8 @@ class TypeTranslatorTest {
                 property("overriddenName", ApiType.Primitive.STRING),
                 property("fieldWithDefaultWillBeNullable", ApiType.Primitive.INTEGER.nullable()),
                 property("nullableParameter", ApiType.Primitive.INTEGER.nullable()),
-                property("requiredFieldWithDefaultWillNotBeNullable", ApiType.Primitive.INTEGER)))
+                property("requiredFieldWithDefaultWillNotBeNullable", ApiType.Primitive.INTEGER),
+                property("valueString", ApiType.Primitive.STRING)))
         }
 
         @Test

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/testclasses/ClassWithValueClasses.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/testclasses/ClassWithValueClasses.kt
@@ -6,12 +6,14 @@ value class ValueString(private val string: String)
 @JvmInline
 value class ValueInteger(private val integer: Int)
 
+@JvmInline
+value class ValueNested(private val v: ValueInteger)
+
 class ClassWithValueClasses {
     var valueString = ValueString("test")
     var valueInteger = ValueInteger(2)
+    var nestedValueInteger = ValueNested(ValueInteger(2))
 
-    private val privateValueString = ValueString("test")
-
-    fun getPrivateValue() = privateValueString
+    fun getGetterValue() = ValueString("test")
 
 }

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/testclasses/ClassWithValueClasses.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/testclasses/ClassWithValueClasses.kt
@@ -1,0 +1,17 @@
+package fi.evident.apina.spring.testclasses
+
+@JvmInline
+value class ValueString(private val string: String)
+
+@JvmInline
+value class ValueInteger(private val integer: Int)
+
+class ClassWithValueClasses {
+    var valueString = ValueString("test")
+    var valueInteger = ValueInteger(2)
+
+    private val privateValueString = ValueString("test")
+
+    fun getPrivateValue() = privateValueString
+
+}

--- a/apina-core/src/test/kotlin/fi/evident/apina/utils/PropertyUtilsTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/utils/PropertyUtilsTest.kt
@@ -6,6 +6,14 @@ import kotlin.test.assertEquals
 class PropertyUtilsTest {
 
     @Test
+    fun propertyNamesForValueGetters() {
+        assertEquals("foo", propertyNameForGetter("getFoo-11MJ8YI"))
+        assertEquals("fooBar", propertyNameForGetter("getFooBar-11MJ8YI"))
+        assertEquals("foo", propertyNameForGetter("isFoo-11MJ8YI"))
+        assertEquals("fooBar", propertyNameForGetter("isFooBar-11MJ8YI"))
+    }
+
+    @Test
     fun propertyNamesForGetters() {
         assertEquals("foo", propertyNameForGetter("getFoo"))
         assertEquals("fooBar", propertyNameForGetter("getFooBar"))


### PR DESCRIPTION
Adds support for Kotlin 1.5 value classes. Workaround for hash suffix removal is similar to what is done in JacksonXML (https://github.com/FasterXML/jackson-module-kotlin/pull/383).

~~Updating to Kotlin 1.5 breaks one test. Kotlin 1.5 generates lambdas via `invokedynamic` which results in generated proxies at runtime instead of classes (https://kotlinlang.org/docs/whatsnew15.html#sam-adapters-via-invokedynamic). That breaks the `ClassMetadataReaderTest#innerClassWithOuterBounds`. This can be avoided by using `freeCompilerArgs += "-Xsam-conversions=class"`. I wasn't really sure what to do about that. What do you think?~~