### PR TITLE
Improve discriminated union type naming

### DIFF
--- a/apina-core/src/main/kotlin/fi/evident/apina/spring/JacksonTypeTranslator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/spring/JacksonTypeTranslator.kt
@@ -66,7 +66,7 @@ internal class JacksonTypeTranslator(
         api.addDiscriminatedUnion(union)
 
         for ((name, cl) in findSubtypes(javaClass)) {
-            val def = ClassDefinition(typeTranslator.classNameForDiscriminatedUnionMember(union.type, cl.type.toBasicType()))
+            val def = ClassDefinition(typeTranslator.classNameForDiscriminatedUnionMember(union.type, javaClass.type.toBasicType(), cl.type.toBasicType()))
             initClassDefinition(def, BoundClass(cl, TypeEnvironment.empty()))
             union.addType(name, def)
         }

--- a/apina-core/src/main/kotlin/fi/evident/apina/spring/KotlinSerializationTypeTranslator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/spring/KotlinSerializationTypeTranslator.kt
@@ -64,7 +64,7 @@ internal class KotlinSerializationTypeTranslator(
         // We assume that the class is sealed and therefore the subtypes must be in the same package
         for (cl in findSealedSubClasses(metadata)) {
             val name = cl.findAnnotation(SERIAL_NAME)?.getAttribute("value") ?: cl.name.replace('$', '.')
-            val def = ClassDefinition(typeTranslator.classNameForDiscriminatedUnionMember(union.type, cl.type.toBasicType()))
+            val def = ClassDefinition(typeTranslator.classNameForDiscriminatedUnionMember(union.type, javaClass.type.toBasicType(), cl.type.toBasicType()))
             initClassDefinition(def, cl, TypeEnvironment.empty())
             union.addType(name, def)
         }

--- a/apina-core/src/main/kotlin/fi/evident/apina/spring/TypeTranslator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/spring/TypeTranslator.kt
@@ -164,19 +164,25 @@ internal class TypeTranslator(
         return registerTranslatedName(type, translatedName)
     }
 
-    fun classNameForDiscriminatedUnionMember(unionType: ApiTypeName, type: JavaType.Basic): ApiTypeName {
+    fun classNameForDiscriminatedUnionMember(unionType: ApiTypeName, unionJavaType: JavaType.Basic, memberType: JavaType.Basic): ApiTypeName {
         val translatedName = when (settings.nestedClassNameMode) {
-            UNQUALIFIED -> settings.nameTranslator.translateClassName(type.name, qualifyNestedClasses = false)
-            QUALIFIED -> settings.nameTranslator.translateClassName(type.name, qualifyNestedClasses = true)
+            UNQUALIFIED -> settings.nameTranslator.translateClassName(memberType.name, qualifyNestedClasses = false)
+            QUALIFIED -> settings.nameTranslator.translateClassName(memberType.name, qualifyNestedClasses = true)
             QUALIFIED_DISCRIMINATED_UNIONS -> {
-                // Use the immediate parent (union type name) to qualify the member
-                val simpleName = settings.nameTranslator.translateClassName(type.name, qualifyNestedClasses = false)
-                "${unionType.name}_${simpleName}"
+                val simpleName = settings.nameTranslator.translateClassName(memberType.name, qualifyNestedClasses = false)
+                if (memberType.isNestedIn(unionJavaType)) {
+                    "${unionType.name}_${simpleName}"
+                } else {
+                    simpleName
+                }
             }
         }
 
-        return registerTranslatedName(type, translatedName)
+        return registerTranslatedName(memberType, translatedName)
     }
+
+    private fun JavaType.Basic.isNestedIn(parentType: JavaType.Basic) =
+        name.startsWith(parentType.name + "$")
 
     private fun registerTranslatedName(type: JavaType.Basic, translatedName: String): ApiTypeName {
         val existingType = translatedNames.putIfAbsent(translatedName, type)

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/KotlinSerializationTypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/KotlinSerializationTypeTranslatorTest.kt
@@ -135,6 +135,31 @@ class KotlinSerializationTypeTranslatorTest {
     // so no separate test needed. The difference only affects non-discriminated-union nested classes.
 
     @Test
+    fun `discriminated union with top-level subclasses should not be qualified in QUALIFIED_DISCRIMINATED_UNIONS mode`() {
+        val qualifiedApi = ApiDefinition()
+        val qualifiedSettings = TranslationSettings()
+        qualifiedSettings.nestedClassNameMode = QUALIFIED_DISCRIMINATED_UNIONS
+        val qualifiedTranslator = TypeTranslator(qualifiedSettings, model, qualifiedApi)
+
+        loader.loadClassesFromInheritanceTree<TopLevelSealedClass>()
+        loader.loadClassesFromInheritanceTree<TopLevelSubclass1>()
+        loader.loadClassesFromInheritanceTree<TopLevelSubclass2>()
+
+        qualifiedTranslator.translateType(
+            JavaType.basic<TopLevelSealedClass>(),
+            MockAnnotatedElement(),
+            TypeEnvironment.empty()
+        )
+
+        val definition = qualifiedApi.discriminatedUnionDefinitions.find { it.type.name == "TopLevelSealedClass" }
+            ?: fail("could not find union")
+
+        // Top-level subclasses should NOT be qualified with the sealed class name
+        val memberTypes = definition.types.values.map { it.type.name }.toSet()
+        assertEquals(setOf("TopLevelSubclass1", "TopLevelSubclass2"), memberTypes)
+    }
+
+    @Test
     fun `nested class naming with QUALIFIED mode`() {
         val qualifiedApi = ApiDefinition()
         val qualifiedSettings = TranslationSettings()
@@ -365,3 +390,13 @@ class KotlinSerializationTypeTranslatorTest {
             ?: fail("could not find definition for $apiType")
     }
 }
+
+// Test classes for top-level sealed class scenario
+@Serializable
+sealed class TopLevelSealedClass
+
+@Serializable
+class TopLevelSubclass1(val value1: String) : TopLevelSealedClass()
+
+@Serializable
+class TopLevelSubclass2(val value2: Int) : TopLevelSealedClass()

--- a/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/spring/TypeTranslatorTest.kt
@@ -340,6 +340,50 @@ class TypeTranslatorTest {
             // ensure that subclasses themselves are not translated
             assertEquals(0, api.classDefinitions.size)
         }
+
+        @Test
+        fun `top-level subclasses should not be qualified in QUALIFIED_DISCRIMINATED_UNIONS mode`() {
+            val qualifiedApi = ApiDefinition()
+            val qualifiedSettings = TranslationSettings()
+            qualifiedSettings.nestedClassNameMode = fi.evident.apina.model.settings.NestedClassNameMode.QUALIFIED_DISCRIMINATED_UNIONS
+            val qualifiedTranslator = TypeTranslator(qualifiedSettings, model, qualifiedApi)
+
+            loader.loadClassesFromInheritanceTree<TopLevelVehicle>()
+            loader.loadClassesFromInheritanceTree<TopLevelCar>()
+            loader.loadClassesFromInheritanceTree<TopLevelBike>()
+
+            qualifiedTranslator.translateType(JavaType.basic<TopLevelVehicle>(), MockAnnotatedElement(), TypeEnvironment.empty())
+
+            assertEquals(1, qualifiedApi.discriminatedUnionDefinitions.size)
+            val definition = qualifiedApi.discriminatedUnionDefinitions.first()
+            assertEquals("TopLevelVehicle", definition.type.name)
+
+            // Top-level subclasses should NOT be qualified with the sealed class name
+            val memberTypes = definition.types.values.map { it.type.name }.toSet()
+            assertEquals(setOf("TopLevelCar", "TopLevelBike"), memberTypes)
+        }
+
+        @Test
+        fun `nested subclasses should be qualified in QUALIFIED_DISCRIMINATED_UNIONS mode`() {
+            val qualifiedApi = ApiDefinition()
+            val qualifiedSettings = TranslationSettings()
+            qualifiedSettings.nestedClassNameMode = fi.evident.apina.model.settings.NestedClassNameMode.QUALIFIED_DISCRIMINATED_UNIONS
+            val qualifiedTranslator = TypeTranslator(qualifiedSettings, model, qualifiedApi)
+
+            loader.loadClassesFromInheritanceTree<Vehicle>()
+            loader.loadClassesFromInheritanceTree<Vehicle.Car>()
+            loader.loadClassesFromInheritanceTree<Vehicle.Truck>()
+
+            qualifiedTranslator.translateType(JavaType.basic<Vehicle>(), MockAnnotatedElement(), TypeEnvironment.empty())
+
+            assertEquals(1, qualifiedApi.discriminatedUnionDefinitions.size)
+            val definition = qualifiedApi.discriminatedUnionDefinitions.first()
+            assertEquals("Vehicle", definition.type.name)
+
+            // Nested subclasses SHOULD be qualified with the parent class name
+            val memberTypes = definition.types.values.map { it.type.name }.toSet()
+            assertEquals(setOf("Vehicle_Car", "Vehicle_Truck"), memberTypes)
+        }
     }
 
     @Test
@@ -417,6 +461,13 @@ class TypeTranslatorTest {
         class Truck : Vehicle2()
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = TopLevelCar::class, name = "car"),
+        JsonSubTypes.Type(value = TopLevelBike::class, name = "bike")
+    )
+    abstract class TopLevelVehicle
+
     private fun translateType(type: JavaType): ApiType =
         translator.translateType(
             type,
@@ -443,3 +494,7 @@ class TypeTranslatorTest {
             ?: fail("could not find definition for $apiType")
     }
 }
+
+// Top-level subclasses for testing discriminated unions with non-nested subclasses
+class TopLevelCar : TypeTranslatorTest.TopLevelVehicle()
+class TopLevelBike : TypeTranslatorTest.TopLevelVehicle()


### PR DESCRIPTION
If the subclasses of the discriminated union are not defined as nested types, don't use the name of the union type in the name.