### PR TITLE
Import types using type-qualifier

### DIFF
--- a/apina-core/src/main/kotlin/fi/evident/apina/output/ts/AbstractTypeScriptGenerator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/output/ts/AbstractTypeScriptGenerator.kt
@@ -15,13 +15,13 @@ import fi.evident.apina.output.common.RawCode
 import fi.evident.apina.utils.readResourceAsString
 import java.lang.String.format
 
-abstract class AbstractTypeScriptGenerator(
+internal abstract class AbstractTypeScriptGenerator(
     val api: ApiDefinition,
     val settings: TranslationSettings,
     private val resultFunctor: ResultFunctor,
     private val classDecorator: String,
     private val platformRuntimeCodePath: String,
-    private val platformSpecificImports: Map<String, List<String>> = emptyMap()
+    private val platformSpecificImports: Map<String, List<ImportDefinition>> = emptyMap()
 ) {
 
     private val out = TypeScriptWriter()
@@ -51,7 +51,7 @@ abstract class AbstractTypeScriptGenerator(
 
         if (imports.isNotEmpty()) {
             for (anImport in imports)
-                out.writeImport(anImport.moduleName, anImport.types.map { it.name })
+                out.writeImport(anImport.moduleName, anImport.types.map { ImportDefinition(it) })
 
             out.writeLine()
         }
@@ -354,6 +354,11 @@ abstract class AbstractTypeScriptGenerator(
                 .distinctBy { it.type }
                 .sortedBy { it.type }
     }
+}
+
+internal class ImportDefinition constructor(val name: String, val onlyType: Boolean = false) {
+    constructor(type: ApiTypeName): this(type.name, onlyType = true)
+    fun code() = if (onlyType) "type $name" else name
 }
 
 internal fun ApiType.toTypeScript(optionalTypeMode: OptionalTypeMode): String = when (this) {

--- a/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptAngularGenerator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptAngularGenerator.kt
@@ -8,7 +8,7 @@ import fi.evident.apina.output.ts.ResultFunctor.PROMISE
 /**
  * Generates Angular TypeScript code for client side.
  */
-class TypeScriptAngularGenerator(api: ApiDefinition, settings: TranslationSettings, resultFunctor: ResultFunctor) :
+internal class TypeScriptAngularGenerator(api: ApiDefinition, settings: TranslationSettings, resultFunctor: ResultFunctor) :
     AbstractTypeScriptGenerator(
         api = api,
         settings = settings,
@@ -19,18 +19,18 @@ class TypeScriptAngularGenerator(api: ApiDefinition, settings: TranslationSettin
             PROMISE -> "typescript/runtime-angular-promise.ts"
         },
         platformSpecificImports = mapOf(
-            "@angular/core" to listOf("Injectable", "Provider", "Type"),
-            "@angular/common/http" to listOf("HttpClient", "HttpParams"),
+            "@angular/core" to listOf(ImportDefinition("Injectable"), ImportDefinition("Provider", onlyType = true), ImportDefinition("Type")),
+            "@angular/common/http" to listOf(ImportDefinition("HttpClient"), ImportDefinition("HttpParams")),
         ) + resultFunctor.functorImports()
     )
 
 private fun ResultFunctor.functorImports() = when (this) {
     PROMISE -> mapOf(
-        "rxjs" to listOf("firstValueFrom"),
+        "rxjs" to listOf(ImportDefinition("firstValueFrom")),
     )
 
     OBSERVABLE -> mapOf(
-        "rxjs" to listOf("Observable"),
-        "rxjs/operators" to listOf("map"),
+        "rxjs" to listOf(ImportDefinition("Observable", onlyType = true)),
+        "rxjs/operators" to listOf(ImportDefinition("map")),
     )
 }

--- a/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptES6Generator.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptES6Generator.kt
@@ -3,7 +3,7 @@ package fi.evident.apina.output.ts
 import fi.evident.apina.model.ApiDefinition
 import fi.evident.apina.model.settings.TranslationSettings
 
-class TypeScriptES6Generator(api: ApiDefinition, settings: TranslationSettings) : AbstractTypeScriptGenerator(
+internal class TypeScriptES6Generator(api: ApiDefinition, settings: TranslationSettings) : AbstractTypeScriptGenerator(
     api = api,
     settings = settings,
     resultFunctor = ResultFunctor.PROMISE,

--- a/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptWriter.kt
+++ b/apina-core/src/main/kotlin/fi/evident/apina/output/ts/TypeScriptWriter.kt
@@ -6,7 +6,7 @@ import fi.evident.apina.output.common.CodeWriter
  * Helper for generating TypeScript code. Keeps track of indentation level
  * and supports proper writing of literal values.
  */
-class TypeScriptWriter : CodeWriter<TypeScriptWriter>() {
+internal class TypeScriptWriter : CodeWriter<TypeScriptWriter>() {
 
     override val self: TypeScriptWriter
         get() = this
@@ -19,8 +19,9 @@ class TypeScriptWriter : CodeWriter<TypeScriptWriter>() {
         writeBlock("export class $name", bodyWriter)
     }
 
-    fun writeImport(module: String, types: Collection<String>) {
-        writeLine("import { ${types.joinToString(", ")} } from '$module';")
+    fun writeImport(module: String, imports: Collection<ImportDefinition>) {
+        val importsStr = imports.joinToString(", ", prefix = "{ ", postfix = " }") { it.code() }
+        writeLine("import $importsStr from '$module';")
     }
 
     fun writeExport(types: Collection<String>) {

--- a/apina-core/src/test/kotlin/fi/evident/apina/output/ts/TypeScriptWriterTest.kt
+++ b/apina-core/src/test/kotlin/fi/evident/apina/output/ts/TypeScriptWriterTest.kt
@@ -97,8 +97,8 @@ class TypeScriptWriterTest {
 
     @Test
     fun imports() {
-        writer.writeImport("@angular/common/http", listOf("HttpClient", "HttpParams"))
+        writer.writeImport("@angular/core", listOf(ImportDefinition("Injectable"), ImportDefinition("Provider", onlyType = true), ImportDefinition("Type")))
 
-        assertEquals("import { HttpClient, HttpParams } from '@angular/common/http';\n", writer.output)
+        assertEquals("import { Injectable, type Provider, Type } from '@angular/core';\n", writer.output)
     }
 }


### PR DESCRIPTION
This makes generated code compatible with `verbatimModuleSyntax: true`.